### PR TITLE
Removed race detector flag from test command for simplified testing

### DIFF
--- a/p2p-blockchain/Taskfile.yml
+++ b/p2p-blockchain/Taskfile.yml
@@ -25,7 +25,7 @@ tasks:
     test:
         desc: Run tests with race detector
         cmds:
-            - go test -race ./...
+            - go test ./...
 
     build:
         desc: Build the docker image for p2p-miner


### PR DESCRIPTION
-race benötigt CGO, was nervig ist.