### PR TITLE
Added RoleBinding for user access in vsp-blockchain namespace

### DIFF
--- a/kubernetes-access.yaml
+++ b/kubernetes-access.yaml
@@ -5,11 +5,11 @@ metadata:
     namespace: vsp-blockchain
 subjects:
     - kind: User
-      name: infwqx847
+      name: wqx847
     - kind: User
-      name: infwwv166
+      name: wwv166
     - kind: User
-      name: infwxv415
+      name: wxv415
 roleRef:
     kind: Role
     name: hnc-user-default


### PR DESCRIPTION
siehe auch https://doc.inf.haw-hamburg.de/Dienste/icc/namespaces/#eigenen-namespace-an-andere-benutzer-freigeben